### PR TITLE
Filters: configurable and arbitrary number of parameters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,6 @@
 ## 0.5.2 to 0.5.3 (unreleased)
 
-(TODO)
-
+ * Events: Subqueries can be extended by the configuration, see the example configuration.
 
 ## 0.5.1 to 0.5.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 ## 0.5.2 to 0.5.3 (unreleased)
 
  * Events: Subqueries can be extended by the configuration, see the example configuration.
+ * Events: Subqueries can need the parameter '%s' more or less than one time in the SQL query, for example:
+   ```
+   ("source.ip" = '%s' OR "destination.ip" = '%s')
+   ```
 
 ## 0.5.1 to 0.5.2
 

--- a/events_api/events_api/serve.py
+++ b/events_api/events_api/serve.py
@@ -58,7 +58,15 @@ EXAMPLE_CONF_FILE = r"""
 {
   "libpg conninfo":
     "host=localhost dbname=intelmq-events user=eventapiuser password='USER\\'s DB PASSWORD'",
-  "logging_level": "INFO"
+  "logging_level": "INFO",
+  "subqueries": {
+     "all_ips": {
+       "sql": "(\"source.ip\" = %s OR \"source.local_ip\" = %s OR \"destination.ip\" = %s OR \"destination.local_ip\" = %s)",
+       "description": "Queries (source|destination).(local_)ip",
+       "label": "Query all IPs",
+       "ext_type": "integer"
+     }
+   }
 }
 """
 
@@ -508,6 +516,9 @@ def setup(api):
         log.setLevel(config["logging_level"])
     open_db_connection(config["libpg conninfo"])
     log.debug("Initialised DB connection for events_api.")
+
+    global QUERY_EVENT_SUBQUERY
+    QUERY_EVENT_SUBQUERY.update(config.get('subqueries', {}))
 
 
 @hug.get(ENDPOINT_PREFIX, examples="id=1")

--- a/events_api/events_api/serve.py
+++ b/events_api/events_api/serve.py
@@ -395,10 +395,10 @@ def query_prepare_export(q):
     for subquerytuple in q:
         if counter > 0:
             q_string = q_string + " AND " + subquerytuple[0]
-            params.append(subquerytuple[1])
+            params.extend((subquerytuple[1], ) * subquerytuple[0].count('%s'))
         else:
             q_string = q_string + " WHERE " + subquerytuple[0]
-            params.append(subquerytuple[1])
+            params.extend((subquerytuple[1], ) * subquerytuple[0].count('%s'))
         counter += 1
     return q_string, params
 
@@ -433,10 +433,10 @@ def query_prepare_search(q):
     for subquerytuple in q:
         if counter > 0:
             q_string = q_string + " AND " + subquerytuple[0]
-            params.append(subquerytuple[1])
+            params.extend((subquerytuple[1], ) * subquerytuple[0].count('%s'))
         else:
             q_string = q_string + " WHERE " + subquerytuple[0]
-            params.append(subquerytuple[1])
+            params.extend((subquerytuple[1], ) * subquerytuple[0].count('%s'))
         counter += 1
     return q_string, params
 
@@ -467,10 +467,10 @@ def query_prepare_stats(q, interval = 'day'):
     for subquerytuple in q:
         if counter > 0:
             q_string = q_string + " AND " + subquerytuple[0]
-            params.append(subquerytuple[1])
+            params.extend((subquerytuple[1], ) * subquerytuple[0].count('%s'))
         else:
             q_string = q_string + " WHERE " + subquerytuple[0]
-            params.append(subquerytuple[1])
+            params.extend((subquerytuple[1], ) * subquerytuple[0].count('%s'))
         counter += 1
     q_string = q_string + " GROUP BY %s ORDER BY date_trunc" % (trunc, )
     return q_string, params


### PR DESCRIPTION
See NEWS.md:

 * Events: Subqueries can be extended by the configuration, for example:
   ```json
   "subqueries": {
     "all_ips": {
       "sql": "(\"source.ip\" = %s OR \"source.local_ip\" = %s OR \"destination.ip\" = %s OR \"destination.local_ip\" = %s)",
       "description": "Queries (source|destination).(local_)ip",
       "label": "Query all IPs",
       "ext_type": "integer"
     }
   }
   ```
 * Events: Subqueries can need the parameter '%s' more or less than one time in the SQL query, for example:
   ```sql
   ("source.ip" = '%s' OR "destination.ip" = '%s')
   ```