### PR TITLE
stats: reconnect to postgres in case of error

### DIFF
--- a/events_api/events_api/serve.py
+++ b/events_api/events_api/serve.py
@@ -464,7 +464,12 @@ def query(prepared_query):
 
     # psycopgy2.4 does not offer 'with' for cursor()
     # FUTURE use with
-    cur = eventdb_conn.cursor(cursor_factory=RealDictCursor)
+    try:
+        cur = eventdb_conn.cursor(cursor_factory=RealDictCursor)
+    except (psycopg2.InterfaceError, psycopg2.InternalError,
+            psycopg2.OperationalError, AttributeError):
+        setup(None)
+        cur = eventdb_conn.cursor(cursor_factory=RealDictCursor)
 
     operation = prepared_query[0]
     parameters = prepared_query[1]

--- a/events_api/events_api/serve.py
+++ b/events_api/events_api/serve.py
@@ -530,10 +530,8 @@ def showSubqueries():
 
     # Remove the SQL Statement from the SQ Object.
     for k, v in subquery_copy.items():
-        try:
+        if 'sql' in v:
             del(v['sql'])
-        except:
-            pass
 
     return subquery_copy
 


### PR DESCRIPTION
reconnects if no cursor can be fetched
still leads to one 500 connection interestingly, but the next will
succeed